### PR TITLE
Actually extract out column

### DIFF
--- a/R/classify_wetdry.R
+++ b/R/classify_wetdry.R
@@ -33,7 +33,7 @@ classify_wetdry <- function(stic_data, classify_var, threshold, method) {
     if (!classify_var == "condUncal") stop("Error - for y-intercept, classify_var should be condUncal")
   }
 
-  class_var <- stic_data[, classify_var]
+  class_var <- stic_data[[classify_var]]
 
   if (method == "percent") {
     if ((threshold > 1) | (threshold < 0)) stop("Error - threshold should be between 0-1")


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package accidentally supplies `if_else()` an _array_ for the first input. This is no longer allowed, it must be a logical vector without a `dim` attribute.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!